### PR TITLE
Update commands for AWS CLI 1.10.35

### DIFF
--- a/KinesisBigQuery.js
+++ b/KinesisBigQuery.js
@@ -1,6 +1,6 @@
 var config = require('./gcpconfig');
 var gcloud = require('gcloud');
-var _ = require('lodash');
+var lodash = require('lodash');
 
 exports.handler = function(event, context) {
   var bigquery = gcloud.bigquery({
@@ -18,7 +18,7 @@ exports.handler = function(event, context) {
     var sequenceNumber = kinesis.sequenceNumber;
     try {
       var payload = JSON.parse(new Buffer(kinesis.data, 'base64').toString('utf8'));
-      rows.push(_.merge({ id: sequenceNumber, time: now }, payload));
+      rows.push(lodash.merge({ id: sequenceNumber, time: now }, payload));
     } catch (err) {
       console.log(err);
       // ignore JSON parse error

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Create Kinesis stream named examplestream
 Wait event source is ready.
 
 ```
-$ aws lambda get-event-source --uuid UUID
+$ aws lambda get-event-source-mapping --uuid UUID
 {
     "Status": "Ok",
     "UUID": "xx4f17f5-f680-4c82-81de-9d2552999b8f",

--- a/cloudformation/lambda-roles.template
+++ b/cloudformation/lambda-roles.template
@@ -21,42 +21,11 @@
             "Statement": [{
               "Effect": "Allow",
               "Action": [
-                "logs:*"
-              ],
-              "Resource": [
-                "arn:aws:logs:*:*:*"
-              ]
-            }]
-          }
-        }]
-      }
-    },
-
-    "LambdaInvokeRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
-            },
-            "Action": "sts:AssumeRole"
-          }]
-        },
-        "Policies": [{
-          "PolicyName": "LambdaInvoke",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "lambda:InvokeFunction",
+                "kinesis:DescribeStream",
                 "kinesis:GetRecords",
                 "kinesis:GetShardIterator",
-                "kinesis:DescribeStream",
-                "kinesis:ListStreams"
+                "kinesis:ListStreams",
+                "logs:*"
               ],
               "Resource": [
                 "*"
@@ -72,11 +41,6 @@
     "ExecutionRole" : {
       "Description" : "An IAM role that Lambda can assume 'adminuser' to access your AWS resources.",
       "Value" : { "Fn::GetAtt" : ["LambdaExecRole", "Arn"] }
-    },
-
-    "PushInvocationRole" : {
-      "Description" : "An IAM role that Amazon S3 can assume 'adminuser' to invoke your Lambda function.",
-      "Value" : { "Fn::GetAtt" : ["LambdaInvokeRole", "Arn"] }
     }
   }
 }

--- a/scripts/create_stream.sh
+++ b/scripts/create_stream.sh
@@ -8,11 +8,8 @@ STREAM_ARN=`aws kinesis describe-stream --stream-name $STREAM_NAME | jq -r '.Str
 
 sleep 30s
 
-IAM_INVOKE_ROLE=`aws iam list-roles | jq -r '.Roles[].Arn' | grep LambdaInvokeRole`
-
-aws lambda add-event-source \
+aws lambda create-event-source-mapping \
   --function-name KinesisBigQuery \
-  --role $IAM_INVOKE_ROLE  \
-  --event-source $STREAM_ARN \
+  --event-source-arn $STREAM_ARN \
   --batch-size 100 \
-  --parameters InitialPositionInStream=LATEST
+  --starting-position LATEST

--- a/scripts/upload_function.sh
+++ b/scripts/upload_function.sh
@@ -41,15 +41,13 @@ zip -r tmp/KinesisBigQuery.zip node_modules/
 IAM_EXEC_ROLE=`aws iam list-roles | jq -r '.Roles[].Arn' | grep LambdaExecRole`
 
 echo "==============="
-echo "Upload function"
-aws lambda upload-function \
+echo "Create function"
+aws lambda create-function \
    --function-name KinesisBigQuery \
-   --function-zip tmp/KinesisBigQuery.zip \
+   --zip-file fileb://tmp/KinesisBigQuery.zip \
    --role $IAM_EXEC_ROLE \
-   --mode event \
    --handler KinesisBigQuery.handler \
    --runtime nodejs \
-   --debug
 
 echo "==============="
 echo "Done"


### PR DESCRIPTION
I updated unworkable commands for AWS CLI 1.10.35. In particular, --role arg for "aws lambda add-event-source" has disabled, so I remove InvocationRole and add the related kinesis actions to ExecutionRole.