### PR TITLE
Update to be compatible with Node.js 4.3 and AWS CLI 1.10.35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.3.2"

--- a/KinesisBigQuery.js
+++ b/KinesisBigQuery.js
@@ -17,8 +17,7 @@ exports.handler = function(event, context) {
     kinesis = event.Records[i].kinesis;
     var sequenceNumber = kinesis.sequenceNumber;
     try {
-      var decode = new Buffer(kinesis.data, 'base64').toString('utf8');
-      var payload = JSON.parse(new Buffer(decode, 'base64').toString('utf8'));
+      var payload = JSON.parse(new Buffer(kinesis.data, 'base64').toString('utf8'));
       rows.push(_.merge({ id: sequenceNumber, time: now }, payload));
     } catch (err) {
       console.log(err);

--- a/KinesisBigQuery.js
+++ b/KinesisBigQuery.js
@@ -17,7 +17,8 @@ exports.handler = function(event, context) {
     kinesis = event.Records[i].kinesis;
     var sequenceNumber = kinesis.sequenceNumber;
     try {
-      var payload = JSON.parse(new Buffer(kinesis.data, 'base64').toString('utf8'));
+      var decode = new Buffer(kinesis.data, 'base64').toString('utf8');
+      var payload = JSON.parse(new Buffer(decode, 'base64').toString('utf8'));
       rows.push(lodash.merge({ id: sequenceNumber, time: now }, payload));
     } catch (err) {
       console.log(err);

--- a/KinesisBigQuery.js
+++ b/KinesisBigQuery.js
@@ -27,7 +27,7 @@ exports.handler = function(event, context) {
   }
   console.log(JSON.stringify(rows, null, '  '));
 
-  table.insert(rows, function (err, insertErrors) {
+  table.insert(rows, function (err, insertErrors, apiResponse) {
     if (err) return context.done(err);
     if (insertErrors && insertErrors.length > 0) {
       insertErrors.forEach(function (insertError) {
@@ -38,7 +38,7 @@ exports.handler = function(event, context) {
       });
       return context.done('error');
     }
-
+    console.log(apiResponse);
     context.done(null, "success");
   });
 };

--- a/KinesisBigQuery.js
+++ b/KinesisBigQuery.js
@@ -1,6 +1,6 @@
 var config = require('./gcpconfig');
 var gcloud = require('gcloud');
-var _ = require('lodash');
+var lodash = require('lodash');
 
 exports.handler = function(event, context) {
   var bigquery = gcloud.bigquery({
@@ -18,7 +18,7 @@ exports.handler = function(event, context) {
     var sequenceNumber = kinesis.sequenceNumber;
     try {
       var payload = JSON.parse(new Buffer(kinesis.data, 'base64').toString('utf8'));
-      rows.push(_.merge({ id: sequenceNumber, time: now }, payload));
+      rows.push(lodash.merge({ id: sequenceNumber, time: now }, payload));
     } catch (err) {
       console.log(err);
       // ignore JSON parse error

--- a/KinesisBigQuery.js
+++ b/KinesisBigQuery.js
@@ -1,6 +1,6 @@
 var config = require('./gcpconfig');
 var gcloud = require('gcloud');
-var lodash = require('lodash');
+var _ = require('lodash');
 
 exports.handler = function(event, context) {
   var bigquery = gcloud.bigquery({
@@ -19,7 +19,7 @@ exports.handler = function(event, context) {
     try {
       var decode = new Buffer(kinesis.data, 'base64').toString('utf8');
       var payload = JSON.parse(new Buffer(decode, 'base64').toString('utf8'));
-      rows.push(lodash.merge({ id: sequenceNumber, time: now }, payload));
+      rows.push(_.merge({ id: sequenceNumber, time: now }, payload));
     } catch (err) {
       console.log(err);
       // ignore JSON parse error

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ aws lambda get-event-source-mapping --uuid UUID
 Create BigQuery table with schema you want.
 
 ```
-$ bq --project_id myproject mk test.kinesis id:string,user_id:string
+$ bq --project_id myproject mk test.kinesis id:string,time:integer,user_id:string
 ```
 
 ### Test put record
@@ -83,7 +83,7 @@ $ bq --project_id myproject mk test.kinesis id:string,user_id:string
 `id` value is automatically set in lambda function
 
 ```
-$ ./scripts/put_record.sh '{"user_id":"test"}'
+$ ./scripts/put_record.sh '{"user_id":"user1"}'
 ```
 
 After put record, run query to confirm data is correctly inserted.
@@ -91,9 +91,9 @@ After put record, run query to confirm data is correctly inserted.
 ```
 $ bq --project_id myproject query "select * from test.kinesis"
 Waiting on bqjob_xxxxx_0000014a72faad47_1 ... (0s) Current status: DONE
-+----------------------------------------------------------+----------+
-|                            id                            | user_id  |
-+----------------------------------------------------------+----------+
-| 49545115243490985018280067714973144582180062593244200962 | user1    |
-+----------------------------------------------------------+----------+
++----------------------------------------------------------+------------+----------+
+|                            id                            |    time    | user_id  |
++----------------------------------------------------------+------------+----------+
+| 49545115243490985018280067714973144582180062593244200962 | 1465459398 | user1    |
++----------------------------------------------------------+------------+----------+
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Create Kinesis stream named examplestream
 Wait event source is ready.
 
 ```
-$ aws lambda get-event-source --uuid UUID
+$ aws lambda get-event-source-mapping --uuid UUID
 {
     "Status": "Ok",
     "UUID": "xx4f17f5-f680-4c82-81de-9d2552999b8f",

--- a/cloudformation/lambda-roles.template
+++ b/cloudformation/lambda-roles.template
@@ -21,42 +21,11 @@
             "Statement": [{
               "Effect": "Allow",
               "Action": [
-                "logs:*"
-              ],
-              "Resource": [
-                "arn:aws:logs:*:*:*"
-              ]
-            }]
-          }
-        }]
-      }
-    },
-
-    "LambdaInvokeRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
-            },
-            "Action": "sts:AssumeRole"
-          }]
-        },
-        "Policies": [{
-          "PolicyName": "LambdaInvoke",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "lambda:InvokeFunction",
+                "kinesis:DescribeStream",
                 "kinesis:GetRecords",
                 "kinesis:GetShardIterator",
-                "kinesis:DescribeStream",
-                "kinesis:ListStreams"
+                "kinesis:ListStreams",
+                "logs:*"
               ],
               "Resource": [
                 "*"
@@ -72,11 +41,6 @@
     "ExecutionRole" : {
       "Description" : "An IAM role that Lambda can assume 'adminuser' to access your AWS resources.",
       "Value" : { "Fn::GetAtt" : ["LambdaExecRole", "Arn"] }
-    },
-
-    "PushInvocationRole" : {
-      "Description" : "An IAM role that Amazon S3 can assume 'adminuser' to invoke your Lambda function.",
-      "Value" : { "Fn::GetAtt" : ["LambdaInvokeRole", "Arn"] }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/hakobera/lambda-kinesis-bigquery/issues"
   },
   "dependencies": {
-    "gcloud": "^0.35.0",
+    "gcloud": "^0.28.0",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/hakobera/lambda-kinesis-bigquery/issues"
   },
   "dependencies": {
-    "gcloud": "^0.13.2",
-    "lodash": "^2.4.1"
+    "gcloud": "^0.35.0",
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "aws-sdk": "^2.1.23",

--- a/scripts/create_stream.sh
+++ b/scripts/create_stream.sh
@@ -8,11 +8,8 @@ STREAM_ARN=`aws kinesis describe-stream --stream-name $STREAM_NAME | jq -r '.Str
 
 sleep 30s
 
-IAM_INVOKE_ROLE=`aws iam list-roles | jq -r '.Roles[].Arn' | grep LambdaInvokeRole`
-
-aws lambda add-event-source \
+aws lambda create-event-source-mapping \
   --function-name KinesisBigQuery \
-  --role $IAM_INVOKE_ROLE  \
-  --event-source $STREAM_ARN \
+  --event-source-arn $STREAM_ARN \
   --batch-size 100 \
-  --parameters InitialPositionInStream=LATEST
+  --starting-position LATEST

--- a/scripts/put_record.sh
+++ b/scripts/put_record.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-DATA=`echo $1 | base64`
 STREAM_NAME=${STREAM_NAME:-examplestream}
 
 echo "Put $1 to $STREAM_NAME"
 aws kinesis put-record \
   --stream-name $STREAM_NAME \
-  --data "$DATA" \
+  --data "$1" \
   --partition-key ${PARTITION_KEY:-shardId-000000000000}

--- a/scripts/put_record.sh
+++ b/scripts/put_record.sh
@@ -6,5 +6,5 @@ STREAM_NAME=${STREAM_NAME:-examplestream}
 echo "Put $1 to $STREAM_NAME"
 aws kinesis put-record \
   --stream-name $STREAM_NAME \
-  --data "$DATA" \
+  --data $DATA \
   --partition-key ${PARTITION_KEY:-shardId-000000000000}

--- a/scripts/put_record.sh
+++ b/scripts/put_record.sh
@@ -6,5 +6,5 @@ STREAM_NAME=${STREAM_NAME:-examplestream}
 echo "Put $1 to $STREAM_NAME"
 aws kinesis put-record \
   --stream-name $STREAM_NAME \
-  --data $DATA \
+  --data "$DATA" \
   --partition-key ${PARTITION_KEY:-shardId-000000000000}

--- a/scripts/upload_function.sh
+++ b/scripts/upload_function.sh
@@ -41,15 +41,13 @@ zip -r tmp/KinesisBigQuery.zip node_modules/
 IAM_EXEC_ROLE=`aws iam list-roles | jq -r '.Roles[].Arn' | grep LambdaExecRole`
 
 echo "==============="
-echo "Upload function"
-aws lambda upload-function \
+echo "Create function"
+aws lambda create-function \
    --function-name KinesisBigQuery \
-   --function-zip tmp/KinesisBigQuery.zip \
+   --zip-file fileb://tmp/KinesisBigQuery.zip \
    --role $IAM_EXEC_ROLE \
-   --mode event \
    --handler KinesisBigQuery.handler \
    --runtime nodejs \
-   --debug
 
 echo "==============="
 echo "Done"

--- a/scripts/upload_function.sh
+++ b/scripts/upload_function.sh
@@ -47,7 +47,7 @@ aws lambda create-function \
    --zip-file fileb://tmp/KinesisBigQuery.zip \
    --role $IAM_EXEC_ROLE \
    --handler KinesisBigQuery.handler \
-   --runtime nodejs \
+   --runtime nodejs4.3 \
 
 echo "==============="
 echo "Done"

--- a/scripts/upload_function.sh
+++ b/scripts/upload_function.sh
@@ -41,7 +41,7 @@ zip -r tmp/KinesisBigQuery.zip node_modules/
 IAM_EXEC_ROLE=`aws iam list-roles | jq -r '.Roles[].Arn' | grep LambdaExecRole`
 
 echo "==============="
-echo "Create function"
+echo "Upload function"
 aws lambda create-function \
    --function-name KinesisBigQuery \
    --zip-file fileb://tmp/KinesisBigQuery.zip \

--- a/test/data/input.js
+++ b/test/data/input.js
@@ -1,5 +1,6 @@
 function b64(obj) {
-  return new Buffer(JSON.stringify(obj), 'utf8').toString('base64');
+  var decode = new Buffer(JSON.stringify(obj), 'utf8').toString('base64');
+  return new Buffer(decode, 'utf8').toString('base64');
 }
 
 var data1 = b64({ user_id: 'user1' });

--- a/test/data/input.js
+++ b/test/data/input.js
@@ -1,6 +1,6 @@
 function b64(obj) {
-  var decode = new Buffer(JSON.stringify(obj), 'utf8').toString('base64');
-  return new Buffer(decode, 'utf8').toString('base64');
+  var encode = new Buffer(JSON.stringify(obj), 'utf8').toString('base64');
+  return new Buffer(encode, 'utf8').toString('base64');
 }
 
 var data1 = b64({ user_id: 'user1' });

--- a/test/data/input.js
+++ b/test/data/input.js
@@ -1,6 +1,5 @@
 function b64(obj) {
-  var encode = new Buffer(JSON.stringify(obj), 'utf8').toString('base64');
-  return new Buffer(encode, 'utf8').toString('base64');
+  return new Buffer(JSON.stringify(obj), 'utf8').toString('base64');
 }
 
 var data1 = b64({ user_id: 'user1' });


### PR DESCRIPTION
Overall
- Update AWS CLI commands to be compatible with ver. 1.10.35
- Upgrade node.js version to 4.3
- Remove LambdaInvokeRole and add the actions to ExecutionRole. Because "aws lambda create-event-source-mapping" cannot specify role respectively. Lambda function is executed only by the user who upload the function.
- Make some changes in README

KinesisBigQuery.js
- Add apiResponse arg to table.insert callback function

scripts/put_record.sh
- Delete base64 encoding of $1
